### PR TITLE
handle function signatures with default value assignments

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ positional arguments:
 | `-i, --interactive` | Whether to prompt about applying each diff hunk. (default: `False`) |
 | `-q, --quiet` | Quiet mode will output only warnings and errors. (default: `False`) |
 | `-d, --debug` | Debug mode will also output info and debug messages. (default: `False`) |
+| `-ll {DEBUG,INFO,WARNING,ERROR}, --log-level {DEBUG,INFO,WARNING,ERROR}` | Set the logging level. (default: `INFO`) |
 
 **waterloo.toml**
 

--- a/tests/refactor/test_annotations.py
+++ b/tests/refactor/test_annotations.py
@@ -221,12 +221,16 @@ def identity():
             "arg1, *, arg2 = 'default'",
             {"arg1": ("int", "blah"), "arg2": ("str", "blah")},
         ),
+        ("self, arg1", {"arg1": ("int", "blah")},),
+        ("cls, arg1", {"arg1": ("int", "blah")},),
     ],
     ids=[
         "arg with default value",
         "arg with default value containing comma",
         "arg with statement as default value",
         "signature with keyword-only args",
+        "method signature",
+        "class-method signature",
     ],
 )
 def test_arg_annotation_signature_validate(signature, arg_annotations):

--- a/waterloo/cli.py
+++ b/waterloo/cli.py
@@ -127,27 +127,12 @@ def main(settings):
         default=False,
         help="Whether to prompt about applying each diff hunk.",
     )
-
-    # NOTE:
-    # this is not the `quiet/debug` flag from `bowler`... our own logging is
-    # not subject to the bowler flag and our default level is INFO, so we have
-    # *two* mutually-exclusive flags - the `debug` flag applies to Bowler but
-    # also sets our log level to DEBUG, meanwhile the `quiet` flag has no
-    # effect on Bowler but sets our log level to WARNING.
-    log_level_group = apply_group.add_mutually_exclusive_group()
-    log_level_group.add_argument(
-        "-q",
-        "--quiet",
-        action="store_true",
-        default=False,
-        help="Quiet mode will output only warnings and errors.",
-    )
-    log_level_group.add_argument(
-        "-d",
-        "--debug",
-        action="store_true",
-        default=False,
-        help="Debug mode will also output info and debug messages.",
+    apply_group.add_argument(
+        "-ll",
+        "--log-level",
+        default=settings.LOG_LEVEL.name,
+        choices=[m.name for m in LogLevel],
+        help="Set the logging level.",
     )
 
     args = parser.parse_args()
@@ -161,10 +146,7 @@ def main(settings):
         settings.REQUIRE_RETURN_TYPE = args.require_return_type
         settings.IMPORT_COLLISION_POLICY = args.import_collision_policy
         settings.UNPATHED_TYPE_POLICY = args.unpathed_type_policy
-        if args.debug:
-            settings.LOG_LEVEL = LogLevel.DEBUG
-        elif args.quiet:
-            settings.LOG_LEVEL = LogLevel.WARNING
+        settings.LOG_LEVEL = args.log_level
 
         inject.clear_and_configure(configuration_factory(settings))
 

--- a/waterloo/refactor/base.py
+++ b/waterloo/refactor/base.py
@@ -37,7 +37,6 @@ class WaterlooQuery(Query):
 
     def __init__(self, *paths, **kwargs) -> None:
         super().__init__(*paths, **kwargs)
-        print(kwargs)
         self.raw_fixers = []
 
     def raw_fixer(self, fx: Type[BaseFix]) -> "WaterlooQuery":

--- a/waterloo/refactor/utils.py
+++ b/waterloo/refactor/utils.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import typing
-from collections import OrderedDict
 from enum import Enum, auto
 from itertools import chain
 from typing import Callable, Dict, Generator, List, Optional, Set, Tuple, Union, cast
@@ -128,10 +127,7 @@ def _flatten_signature(elements: List[Union[Node, Leaf]]) -> Generator[str, None
             continue
 
 
-def args_annotations_match_signature(
-    arg_annotations: OrderedDict[str, Optional[TypeDef]],
-    signature: List[Union[Node, Leaf]],
-) -> bool:
+def arg_names_from_signature(signature: List[Union[Node, Leaf]]) -> Set[str]:
     """
     Compare the argument names we have parsed from the docstring annotations
     with those found in the function signature.
@@ -157,7 +153,8 @@ def args_annotations_match_signature(
         else:
             raise UnexpectedNodeType(element)
 
-    return arg_annotations.keys() == signature_args
+    signature_args -= {"self", "cls"}
+    return signature_args
 
 
 @inject.params(settings="settings")


### PR DESCRIPTION
fixes: #21 

NOTE:  
this fix still won't handle signatures where the function is already annotated with Py3 annotations, but that means func will be skipped... seems ok for now as we don't want to re-annotate them, although the error message will misleading _"arg names are inconsistent with the function signature"_

(we currently have no checking for that case... we expect that code is not already annotated in Py3 style)